### PR TITLE
use full url to prevent any issues with the share function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.4] - 2025-01-21
+
+Correct Invite Share Links
+
+### Fixed
+
+- Correct Invite Share Links URL
+
+---
+
 ## [1.0.3] - 2025-01-20
 
 Correct Middleware route matcher for the board dynamic route

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiertogether",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "private": true,
     "scripts": {
         "dev": "next dev --turbopack",

--- a/src/app/components/Buttons/InviteUserButton.jsx
+++ b/src/app/components/Buttons/InviteUserButton.jsx
@@ -48,7 +48,7 @@ export default function InviteUserButton({ boardId, boardName, size }) {
 
     const handleShare = async () => {
         navigator.share({
-            url: `invite/${data}`,
+            url: `https://tiertogether.com/invite/${data}`,
             title: "tiertogether Invite",
             text: `You\'ve been invited to ${boardName}!`,
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated invite link functionality so shared invitations now include the full website address, ensuring recipients are directed to the correct application location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->